### PR TITLE
:wrench: Reduce update lib interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "11:00"
     timezone: Asia/Tokyo
   open-pull-requests-limit: 20


### PR DESCRIPTION
libのアップデートがdailyだと作業負荷とリターンがあまり高くないのでmonthlyに変更します