### PR TITLE
Timeout options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/container_ship/cli.rb
+++ b/lib/container_ship/cli.rb
@@ -16,8 +16,10 @@ module ContainerShip
     end
 
     desc 'exec CLUSTER_NAME SERVICE_NAME ENVIRONMENT BUILD_NUMBER', 'exec specified task'
+    method_option 'timeout', desc: 'Timeout seconds for executing the task. Default 5 minutes.'
     def exec(cluster_name, service_name, environment, build_number)
-      Command::ExecCommand.new.run(cluster_name, service_name, environment, build_number)
+      timeout = options['timeout']&.to_i || 300
+      Command::ExecCommand.new.run(cluster_name, service_name, environment, build_number, timeout: timeout)
     end
 
     desc 'version', 'display gem version'

--- a/lib/container_ship/command/exec_command.rb
+++ b/lib/container_ship/command/exec_command.rb
@@ -17,7 +17,7 @@ module ContainerShip
       include Modules::Ecs
       include Modules::PrintTask
 
-      def run(cluster_name, task_name, environment, build_number)
+      def run(cluster_name, task_name, environment, build_number, timeout: nil)
         task_definition = TaskDefinition.new(cluster_name, 'tasks', task_name, environment, build_number)
 
         push_image task_definition
@@ -31,7 +31,7 @@ module ContainerShip
         end
 
         exit_status = print_around_task('Waiting task is completed... ') do
-          wait_task task_definition, task_arn
+          wait_task task_definition, task_arn, timeout: timeout
         end
 
         show_log task_definition, task_arn

--- a/lib/container_ship/command/modules/docker.rb
+++ b/lib/container_ship/command/modules/docker.rb
@@ -5,7 +5,9 @@ module ContainerShip
     module Modules
       module Docker
         def push_image(task_definition)
+          puts "docker build -t \"#{task_definition.image_name}:#{task_definition.build_number}\" ."
           sh "docker build -t \"#{task_definition.image_name}:#{task_definition.build_number}\" ."
+          puts "docker push #{task_definition.image_name}:#{task_definition.build_number}"
           sh "docker push #{task_definition.image_name}:#{task_definition.build_number}"
         end
 
@@ -13,8 +15,9 @@ module ContainerShip
 
         def sh(command)
           status = nil
-          Open3.popen3(command) do |_i, o, _e, w|
+          Open3.popen3(command) do |_i, o, e, w|
             o.each { |line| puts line }
+            e.each { |line| puts line }
             status = w.value
           end
           exit(status.exitstatus) unless status.success?


### PR DESCRIPTION
This PR has the following changes.
In the now, 'container_ship exec' command returns timeout exit code `124` if long ecs tasks (longer than about 5 minutes) is executed.
This PR allows the command to return success exit code with long ecs tasks.

- Users can set timeout seconds by using 'exec' command
  - ex. `$ bundle exec container_ship exec seibii sample_script staging 20210917 --timeout=6000`
  - In the above command, timeout is 10 minutes.
  - Default timeout is 5 minutes. (Not changed)
- Improved timeout logic