### PR TITLE
Allow ECS run_tasks options to be specified

### DIFF
--- a/lib/container_ship/command/modules/ecs.rb
+++ b/lib/container_ship/command/modules/ecs.rb
@@ -23,7 +23,8 @@ module ContainerShip
           aws_ecs_client
             .run_task(
               cluster: task_definition.full_cluster_name,
-              task_definition: "#{task_definition.full_name}:#{revision}"
+              task_definition: "#{task_definition.full_name}:#{revision}",
+              **task_definition.run_task_options
             )
             .tasks
             .first

--- a/lib/container_ship/task_definition.rb
+++ b/lib/container_ship/task_definition.rb
@@ -49,6 +49,16 @@ module ContainerShip
       "#{prefix}/#{full_name}/#{task_arn.split('/').last}"
     end
 
+    def run_task_options
+      @run_task_options ||= begin
+        if File.exists?(run_task_options_path)
+          JSON.parse(File.read(run_task_options_path), symbolize_names: true)
+        else
+          {}
+        end
+      end
+    end
+
     private
 
     def task_definition_hash
@@ -61,6 +71,10 @@ module ContainerShip
 
     def main_container_definition
       task_definition_hash[:container_definitions].find { |definition| definition[:essential] }
+    end
+
+    def run_task_options_path
+      File.join('.container_ship', @cluster_name, @type, @name, @environment, 'run_task_options.json')
     end
   end
 end

--- a/lib/container_ship/version.rb
+++ b/lib/container_ship/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContainerShip
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
fargate環境でrun_taskを実行可能にするためにoptionを指定できるようにしました。

### 対応内容
* run_taskのoptionは複雑なので引数で指定するのは現実的でない。故にpathで指定するのが良さそうに感じた
* task_definitionとrun_taskのoptionは直接的には関係ないが、task実行用のコンテキストもセットで定義してしまっても運用上は大抵問題ない

結果、`.container_ship/<cluster_name>/tasks/<task_name>/<env>/run_task_options.json`
のファイル内容をrun_taskのオプションに指定する形にしました