### PR TITLE
Use the latest CircleCI Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ git statusrestore_bundle_cache: &restore_bundle_cache
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.7.2
+      - image: cimg/ruby:2.7.2
     steps:
       - checkout
       - *restore_bundle_cache
@@ -29,7 +29,7 @@ jobs:
             - vendor/bundle
   rubocop:
     docker:
-      - image: circleci/ruby:2.7.2
+      - image: cimg/ruby:2.7.2
     steps:
       - checkout
       - *restore_bundle_cache
@@ -38,7 +38,7 @@ jobs:
       - run: bundle exec rubocop
   rspec:
     docker:
-      - image: circleci/ruby:2.7.2
+      - image: cimg/ruby:2.7.2
     steps:
       - checkout
       - *restore_bundle_cache


### PR DESCRIPTION
CircleCI has announced the availability of the next generation of their Docker images.
So, the legacy Docker images have been deprecated and are no longer maintained.

See also:
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/
- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034